### PR TITLE
UnoCSS plugin use uno.config.ts

### DIFF
--- a/plugins/unocss.ts
+++ b/plugins/unocss.ts
@@ -2,6 +2,7 @@ import {
   UnoGenerator,
   type UserConfig,
 } from "https://esm.sh/@unocss/core@0.55.1";
+import type { Theme } from "https://esm.sh/@unocss/preset-uno@0.55.1";
 import { Plugin } from "$fresh/server.ts";
 import { exists } from "$fresh/src/server/deps.ts";
 
@@ -14,6 +15,13 @@ type UnoCssPluginOptions = {
   runtime?: boolean;
   config?: UserConfig;
 };
+
+/**
+ * Helper function for typing of config objects
+ */
+export function defineConfig<T extends object = Theme>(config: UserConfig<T>) {
+  return config;
+}
 
 /**
  * UnoCSS plugin - automatically generates CSS utility classes

--- a/plugins/unocss.ts
+++ b/plugins/unocss.ts
@@ -3,35 +3,61 @@ import {
   type UserConfig,
 } from "https://esm.sh/@unocss/core@0.55.1";
 import { Plugin } from "$fresh/server.ts";
+import { exists } from "$fresh/src/server/deps.ts";
 
 // inline reset from https://esm.sh/@unocss/reset@0.54.2/tailwind.css
 const unoResetCSS = `/* reset */
 *,:before,:after{box-sizing:border-box;border:0 solid}html{-webkit-text-size-adjust:100%;-moz-tab-size:4;tab-size:4;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;line-height:1.5}body{line-height:inherit;margin:0}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-size:100%;font-weight:inherit;line-height:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}button,[type=button],[type=reset],[type=submit]{-webkit-appearance:button;background-color:#0000;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dl,dd,h1,h2,h3,h4,h5,h6,hr,figure,p,pre{margin:0}fieldset{margin:0;padding:0}legend{padding:0}ol,ul,menu{margin:0;padding:0;list-style:none}textarea{resize:vertical}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}button,[role=button]{cursor:pointer}:disabled{cursor:default}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}img,video{max-width:100%;height:auto}
 `;
 
-export interface Config<T extends object = object> extends UserConfig<T> {
-  /** The import.meta.url of the module defining these options. */
-  selfURL: string;
-}
+type UnoCssPluginOptions = {
+  runtime?: boolean;
+  config?: UserConfig;
+};
 
-export function defineConfig<T extends object = object>(config: Config<T>) {
-  return config;
-}
+/**
+ * UnoCSS plugin - automatically generates CSS utility classes
+ *
+ * @param [opts] Plugin options
+ * @param [opts.runtime] By default the UnoCSS runtime will run in the browser. Set to `false` to disable this.
+ * @param [opts.config] Explicit UnoCSS config object. By default `uno.config.ts` file. Not supported with the browser runtime.
+ */
+export default async function unocss(
+  opts: UnoCssPluginOptions = {},
+): Promise<Plugin> {
+  // Include the browser runtime by default
+  const runtime = opts.runtime ?? true;
 
-export default function unocss(config: Config, runtime = true): Plugin {
+  // If a config object is not provided, a uno.config.ts file is required in the project directory
+  const configURL = new URL("./uno.config.ts", Deno.mainModule);
+  if (
+    opts.config === undefined &&
+    !await exists(configURL, { isFile: true, isReadable: true })
+  ) {
+    throw new Error(
+      "uno.config.ts not found in the project directory! Please create it or pass a config object to the UnoCSS plugin",
+    );
+  }
+
+  const config: UserConfig = opts.config ??
+    (await import(configURL.toString())).default;
+
   const uno = new UnoGenerator(config);
+
   return {
     name: "unocss",
-    entrypoints: {
-      "main": `
+    entrypoints: runtime
+      ? {
+        "main": `
         data:application/javascript,
-        import config from "${config.selfURL}";
+        import config from "${configURL}";
         import init from "https://esm.sh/@unocss/runtime@0.55.1";
         export default function() {
           window.__unocss = config;
           init();
         }`,
-    },
+      }
+      : {},
     async renderAsync(ctx) {
       const { htmlText } = await ctx.renderAsync();
       const { css } = await uno.generate(htmlText);

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -7,6 +7,7 @@ export {
   toFileUrl,
 } from "https://deno.land/std@0.193.0/path/mod.ts";
 export { walk } from "https://deno.land/std@0.193.0/fs/walk.ts";
+export { exists } from "https://deno.land/std@0.193.0/fs/exists.ts";
 export * as colors from "https://deno.land/std@0.193.0/fmt/colors.ts";
 export {
   type Handler as ServeHandler,

--- a/tests/fixture_unocss_hydrate/options.ts
+++ b/tests/fixture_unocss_hydrate/options.ts
@@ -1,7 +1,6 @@
 import { FreshOptions } from "$fresh/server.ts";
-import unocssPlugin, { type Config } from "$fresh/plugins/unocss.ts";
-import unocssConfig from "./uno.config.ts";
+import unocssPlugin from "$fresh/plugins/unocss.ts";
 
 export default {
-  plugins: [unocssPlugin(unocssConfig as Config)],
+  plugins: [await unocssPlugin()],
 } as FreshOptions;

--- a/tests/fixture_unocss_hydrate/uno.config.ts
+++ b/tests/fixture_unocss_hydrate/uno.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from "$fresh/plugins/unocss.ts";
+import type { UserConfig } from "https://esm.sh/@unocss/core@0.55.1";
 import presetUno from "https://esm.sh/@unocss/preset-uno@0.55.1";
 
-export default defineConfig({
+export default {
   presets: [presetUno()],
-  selfURL: import.meta.url,
-});
+} as UserConfig;


### PR DESCRIPTION
- Import config from uno.config.ts if no config object is explicitly provided
- Always use uno.config.ts as the import source for the browser runtime config
- This avoids the complexity of selfURL, allowing the plugin to use standard Uno config files
