### PR TITLE
Make UnoCSS plugin function synchronous

### DIFF
--- a/tests/fixture_unocss_hydrate/options.ts
+++ b/tests/fixture_unocss_hydrate/options.ts
@@ -2,5 +2,5 @@ import { FreshOptions } from "$fresh/server.ts";
 import unocssPlugin from "$fresh/plugins/unocss.ts";
 
 export default {
-  plugins: [await unocssPlugin()],
+  plugins: [unocssPlugin()],
 } as FreshOptions;


### PR DESCRIPTION
This seems to work. Fresh should terminate with an unhandled promise rejection if the config file is required and not found.